### PR TITLE
Configurable channel timeout

### DIFF
--- a/src/amqp_manager.ts
+++ b/src/amqp_manager.ts
@@ -35,6 +35,7 @@ export class AmqpManager extends EventEmitter {
          queues: [],
          exchanges: [],
          bindings: [],
+         channel_timeout: 2000,
       })
 
       this.fsm = new AmqpConnectionFsm(this.config)
@@ -124,7 +125,7 @@ export class AmqpManager extends EventEmitter {
 
          setTimeout(() => {
             reject(new Error('Channel Timeout'))
-         }, 2000)
+         }, this.config.channel_timeout)
       })
 
       if (!this.waitReady) {

--- a/src/amqp_manager.ts
+++ b/src/amqp_manager.ts
@@ -14,7 +14,7 @@ export class AmqpManager extends EventEmitter {
    private connection: Amqp.Connection
    private channels: _.Dictionary<Amqp.Channel | Amqp.ConfirmChannel>
 
-   constructor(config: T.AmqpConfig) {
+   constructor(config: Partial<T.AmqpConfig>) {
       super()
 
       this.channels = {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,5 +39,5 @@ export interface AmqpConfig {
    exchanges: AmqpExchangeConfig[]
    queues: AmqpQueueConfig[]
    bindings: AmqpBindingConfig[]
-   channel_timeout?: number
+   channel_timeout: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,4 +39,5 @@ export interface AmqpConfig {
    exchanges: AmqpExchangeConfig[]
    queues: AmqpQueueConfig[]
    bindings: AmqpBindingConfig[]
+   channel_timeout?: number
 }


### PR DESCRIPTION
When moving to a parallelized ampq setup, we encountered occasional channel timeouts when trying to open a new channel (5% of attempted connections). Although a little more digging to confirm the root cause is warranted, bumping the timeout up from 2 seconds resolved the timeout issues.

I'm a little uncertain making `channel_timeout` an optional property, as it's required for the timeout to function properly, but want to maintain backwards compatibility. The concern is that if the default was removed (ln. 38, amqp_manager.ts), the type system would not complain, yet the timeout would not function correctly.

A potential solution is to change the private declaration of the config to `private config: T.AmqpConfig & { channel_timeout: number }`, allowing `channel_timeout` to be optionally defined in the config, yet forcing it to exist on the private class property, avoiding any unintentional mistakes. This feels a messy, and ultimately, unnecessary, as we're in control of the config default.